### PR TITLE
infra: add Windsurf/Cascade configuration and workflows

### DIFF
--- a/.windsurf/README.md
+++ b/.windsurf/README.md
@@ -1,0 +1,18 @@
+Windsurf workspace configuration for litecky-editing-services
+
+Overview
+- This folder provides project-aware Windsurf configuration for reliable agentic development.
+- It wires up common MCP servers, defines Cascade workflows aligned to our pnpm scripts, and scopes context to the most relevant paths.
+
+What’s included
+- mcp.json — Registers useful MCP servers via pnpm dlx (no global installs).
+- cascade.yaml — Opinionated workflows for dev loop, validation, and testing.
+
+Prerequisites
+- Node and pnpm versions are managed by mise (.mise.toml). Run `mise install` in the repo root.
+- Install deps once with `pnpm install` before running workflows that spawn the dev server.
+
+Notes
+- No secrets are stored here. If any workflow needs API keys, use your local Windsurf model/account settings or environment variables from `.env`/`.dev.vars` (see ENVIRONMENT.md).
+- If Cascade reports an “Invalid argument” error, it typically indicates a malformed YAML key or an unsupported workflow step. Validate YAML and ensure commands exist in package.json.
+

--- a/.windsurf/cascade.yaml
+++ b/.windsurf/cascade.yaml
@@ -1,0 +1,76 @@
+# Windsurf Cascade configuration for this repository
+# Focuses agent workflows around pnpm scripts and key paths.
+
+version: 1
+
+context:
+  include:
+    - "src/**"
+    - "tests/**"
+    - "docs/**"
+    - "policy/**"
+    - "scripts/**"
+    - "desired-state/**"
+    - "workers/**"
+    - "functions/**"
+    - "public/**"
+    - "astro.config.mjs"
+    - "package.json"
+    - "playwright.config.ts"
+    - "tsconfig.json"
+    - "vitest.config.ts"
+    - ".mise.toml"
+    - ".prettierrc.json"
+    - "eslint.config.js"
+    - "lefthook.yml"
+    - "wrangler.toml"
+    - "README.md"
+    - "AGENTS.md"
+    - "ENVIRONMENT.md"
+    - "ARCHITECTURE.md"
+  exclude:
+    - "node_modules/**"
+    - "dist/**"
+    - ".astro/**"
+    - "playwright-report/**"
+    - "test-results/**"
+
+workflows:
+  - name: "Dev Loop"
+    description: "Plan, implement, and validate changes with tests and linting"
+    steps:
+      - run: "pnpm install"
+      - run: "pnpm check"
+      - run: "pnpm test"
+      - run: "pnpm test:e2e"
+      - run: "pnpm lint:fix"
+
+  - name: "Quick Validate"
+    description: "Fast repo gates + typecheck"
+    steps:
+      - run: "pnpm validate:all"
+      - run: "pnpm typecheck"
+
+  - name: "A11y + E2E"
+    description: "Accessibility checks and E2E tests"
+    steps:
+      - run: "pnpm test:a11y"
+      - run: "pnpm test:e2e"
+
+  - name: "Build Preview"
+    description: "Typecheck and build for local preview"
+    steps:
+      - run: "pnpm build"
+      - run: "pnpm preview"
+
+  - name: "Docs Gate"
+    description: "Ensure docs are in sync before push"
+    steps:
+      - run: "pnpm gate:docs"
+
+  - name: "Policy Gate"
+    description: "Validate repo structure and policy checks"
+    steps:
+      - run: "pnpm validate:all"
+      - run: "pnpm policy:check"
+

--- a/.windsurf/mcp.json
+++ b/.windsurf/mcp.json
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "--root",
+        "."
+      ]
+    },
+    "ripgrep": {
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "-y",
+        "@modelcontextprotocol/server-ripgrep"
+      ]
+    },
+    "git": {
+      "command": "pnpm",
+      "args": [
+        "dlx",
+        "-y",
+        "@modelcontextprotocol/server-git"
+      ]
+    }
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ pnpm test:e2e     # Run Playwright tests
 pnpm lint:fix     # Auto-fix linting issues
 ```
 
+## Windsurf/Cascade
+
+- **Config location**: `.windsurf/` contains `cascade.yaml` and `mcp.json`.
+- **Workflows** (run from Windsurf/Cascade panel):
+  - **Dev Loop**: `pnpm install` → `pnpm check` → `pnpm test` → `pnpm test:e2e` → `pnpm lint:fix`
+  - **Quick Validate**: `pnpm validate:all` → `pnpm typecheck`
+  - **A11y + E2E**: `pnpm test:a11y` → `pnpm test:e2e`
+  - **Build Preview**: `pnpm build` → `pnpm preview`
+  - **Docs Gate**: `pnpm gate:docs`
+  - **Policy Gate**: `pnpm validate:all` → `pnpm policy:check`
+- **Context**: Cascade focuses on `src/`, `tests/`, `docs/`, `policy/`, `scripts/`, `desired-state/`, `workers/`, `functions/`, and key config files (`astro.config.mjs`, `package.json`, etc.).
+- **MCP servers**: Filesystem, Ripgrep, and Git via `pnpm dlx` (see `.windsurf/mcp.json`). No global installs required.
+- **Prereqs**: Run `mise install` then `pnpm install` before using workflows that start the dev server.
+
 ## Styling
 
 - Single source of truth: `src/styles/global.css`.


### PR DESCRIPTION
## Summary
Configures Windsurf/Cascade for project-aware agentic development with workflows aligned to pnpm scripts.

## Changes
- **.windsurf/cascade.yaml**: 6 pre-configured workflows
  - **Dev Loop**: \`pnpm install\` → \`pnpm check\` → \`pnpm test\` → \`pnpm test:e2e\` → \`pnpm lint:fix\`
  - **Quick Validate**: \`pnpm validate:all\` → \`pnpm typecheck\`
  - **A11y + E2E**: \`pnpm test:a11y\` → \`pnpm test:e2e\`
  - **Build Preview**: \`pnpm build\` → \`pnpm preview\`
  - **Docs Gate**: \`pnpm gate:docs\`
  - **Policy Gate**: \`pnpm validate:all\` → \`pnpm policy:check\`
- **Expanded context**: includes \`workers/\`, \`functions/\`, and key config files
- **.windsurf/mcp.json**: MCP servers via \`pnpm dlx\` (no global installs)
  - Filesystem, Ripgrep, Git
- **.windsurf/README.md**: Configuration documentation and prerequisites
- **README.md**: Documents Windsurf/Cascade workflows, context, and usage

## Benefits
- ✅ Standardized development workflows accessible via Windsurf/Cascade panel
- ✅ Context-aware AI assistance focused on relevant project paths
- ✅ No global dependencies (uses \`pnpm dlx\` for MCP servers)
- ✅ Aligned with existing pnpm scripts and validation gates

## Validation
- ✅ All quality gates passed (\`pnpm validate:all\`)
- ✅ Pre-commit hooks passed (package versions, repo structure)
- ✅ Repository structure validated
- ✅ No forbidden files detected

## Usage
After merge, developers can:
1. Run \`mise install\` and \`pnpm install\` (one-time setup)
2. Open Windsurf/Cascade panel
3. Execute any of the 6 pre-configured workflows
4. MCP servers auto-start via \`pnpm dlx\` when needed