### PR TITLE
fix(admin-cms): allow 'unsafe-eval' in admin CSP to resolve Decap AJV codegen errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- fix(admin-cms): allow 'unsafe-eval' in admin CSP when self-hosting Decap CMS to resolve AJV codegen console errors. Scoped to `/admin/*` via Pages Function; no change to main-site CSP.
+

--- a/functions/admin/[[path]].ts
+++ b/functions/admin/[[path]].ts
@@ -30,7 +30,8 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
 		"style-src 'self' 'unsafe-inline'",
 		"img-src 'self' data: blob: https:",
 		"font-src 'self' data:",
-		"script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
+		// Decap CMS uses AJV codegen which requires 'unsafe-eval' in admin only
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
 		"connect-src 'self' https://api.github.com https://github.com https://api.netlify.com https://litecky-decap-oauth.jeffreyverlynjohnson.workers.dev",
 		"frame-src 'self' https://challenges.cloudflare.com",
 		"child-src 'self' blob:",


### PR DESCRIPTION
# Summary
        - Adds 'unsafe-eval' to admin CSP, scoped to /admin/* via Pages Function, to
            resolve Decap AJV codegen EvalError in console.
          - Keeps CSP strict on main site; only admin is relaxed.
      - Changes
          - functions/admin/[[path]].ts: add 'unsafe-eval' to script-src
          - CHANGELOG.md: Unreleased note
      - Tests
          - pnpm test:cms:prod passes (4/4)
          - Verifies no console CSP violations on /admin/
      - Risk/Scope
          - Limited to /admin/*; no impact to main site CSP
          - Matches Decap self-hosting requirement
      - Follow-ups
          - If/when Decap removes AJV codegen requirement, remove 'unsafe-eval' and keep
            tests to enforce