### PR TITLE
fix(oauth): post token to opener origin (supports apex and www)

### DIFF
--- a/PROJECT-STATUS.md
+++ b/PROJECT-STATUS.md
@@ -28,7 +28,7 @@
 - Site responding at https://www.liteckyeditingservices.com (200 OK)
 - SSL certificates active and valid
 - Security headers present with CSP fix deployed (data: URI support)
-- Admin panel functional at /admin/
+- Admin panel functional at /admin/ (GitHub OAuth end-to-end)
 - Automatic builds triggered by Git commits
 - All security headers E2E tests passing (15/15)
 
@@ -36,6 +36,7 @@
   - ✅ **CSP Fix (Pages Function)**: Created `functions/admin/[[path]].ts` to set single authoritative CSP for /admin/* routes
   - ✅ **Header Merging Resolved**: Eliminated duplicate CSP headers by using Cloudflare Pages Function instead of _headers file
   - ✅ **October 2025 Best Practice**: Implemented programmatic header control for complex CSP scenarios
+  - ✅ **OAuth Origin Fix**: OAuth worker now posts token back to the opener origin captured at /auth (supports apex and www), resolving the "Authenticated successfully" but no login continuation when visiting admin on www.
 
 **Recent Progress - October 6, 2025**:
   - ✅ **Visual Baselines (Linux)**: Seeded from main; stored under `tests/e2e/__screenshots__/...`
@@ -814,4 +815,3 @@ All packages using `latest` specifier for automatic updates within semver constr
 
 **Last Updated**: October 2, 2025 (20:50 UTC)
 **Next Review**: After DNS migration
-


### PR DESCRIPTION
Summary
- Fix OAuth popup completion on /admin when opened from www.
- Capture opener Origin at /auth and postMessage token to that origin at /callback.
- Strict allowlist of site origins (apex + www). Clears cookie after use.

Changes
- workers/decap-oauth/src/index.ts: post message to opener origin; set/clear decap_oauth_origin cookie; keep allowed origins list.
- PROJECT-STATUS.md: document OAuth origin fix and admin end-to-end status.

Risk/Scope
- Affects only OAuth Worker; site remains unchanged. Admin login completes on both apex and www.

Validation
- Re-run CMS login on https://liteckyeditingservices.com/admin/ and https://www.liteckyeditingservices.com/admin/ to confirm popup closes and CMS loads.

Follow-ups
- If you add a custom CMS subdomain, add it to the allowed origins list.
